### PR TITLE
Add Dependabot update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10203,7 +10203,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.2.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "license": "MIT",
       "dependencies": {
         "queue": "6.0.2"


### PR DESCRIPTION
[Bump image-size from 1.2.0 to 1.2.1](https://github.com/clearml/clearml-docs/commit/3e3c417e99d59b5e2d610047fbc970da6d65cf4c)