### PR TITLE
Add dependabot update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8654,7 +8654,9 @@
       }
     },
     "node_modules/estree-util-value-to-estree": {
-      "version": "3.3.2",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.3.3.tgz",
+      "integrity": "sha512-Db+m1WSD4+mUO7UgMeKkAwdbfNWwIxLt48XF2oFU9emPfXkIu+k5/nlOj313v7wqtAPo0f9REhUvznFrPkG8CQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"


### PR DESCRIPTION
[Bump estree-util-value-to-estree from 3.3.2 to 3.3.3](https://github.com/clearml/clearml-docs/commit/e7ee1d4abdfd0913c59e07685ef35d039afb06da)