### PR TITLE
Add Dependabot update 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10127,7 +10127,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",


### PR DESCRIPTION
[Bump http-proxy-middleware from 2.0.7 to 2.0.9](https://github.com/clearml/clearml-docs/commit/a9240cc335627af1df53e7521f8df4c4574c713a)